### PR TITLE
Implement flexible LOB encoder

### DIFF
--- a/lob/coder.go
+++ b/lob/coder.go
@@ -1,0 +1,87 @@
+// Package lob implemnets the Length-Object-Binary encoding (Packet Format).
+//
+// Reference
+//
+// https://github.com/telehash/telehash.org/blob/master/v3/lob.md
+package lob
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// ErrInvalidPacket is returned if the data is not valid LOB encoding
+var ErrInvalidPacket = errors.New("invalid lob Packet")
+
+// ErrNonJSONHeader is returend if an emtpy or binary header is decoded as JSON
+var ErrNonJSONHeader = errors.New("non JSON header, length is <7 bytes")
+
+// ErrHeaderTooLong is returned if the header to be encoded is longer than what is supported by LOB
+var ErrHeaderTooLong = fmt.Errorf("header is too long, must be less then %d bytes", math.MaxUint16)
+
+// Header represents a LOB header
+// It can either be emtpy, plain binary data, or JSON
+type Header []byte
+
+// DecodeJSON will try to decode the given Header as JSON and populate the passed in struct v
+// It will return a ErrNonJSONHeader if the lenght of the header is < 7 bytes
+// or it will return an error form encoding/json if the data is non valid JSON
+func (h *Header) DecodeJSON(v interface{}) error {
+	if len(*h) < 7 {
+		return ErrNonJSONHeader
+	}
+
+	return json.Unmarshal(*h, &v)
+}
+
+// EncodeJSON encodes the given struct v as JSON and stores the binary representation in the Header
+func (h *Header) EncodeJSON(v interface{}) (err error) {
+	*h, err = json.Marshal(&v)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Packet represents a Packet.
+type Packet struct {
+	Head Header
+	Body []byte
+}
+
+// MarshalBinary encodes the Packte Header and Body into a LOB encoded byte array
+// This array is in BigEndian (network order)
+func (p *Packet) MarshalBinary() (data []byte, err error) {
+	var b bytes.Buffer
+
+	// Header length is always 2 bytes and big endian (network order)
+	if len(p.Head) > math.MaxUint16 {
+		return nil, ErrHeaderTooLong
+	}
+	length := make([]byte, 2)
+	binary.BigEndian.PutUint16(length, uint16(len(p.Head)))
+
+	b.Write(length)
+	b.Write(p.Head)
+	b.Write(p.Body)
+
+	return b.Bytes(), nil
+}
+
+// UnmarshalBinary decodes a LOB encoded byte array into a Packet struct
+func (p *Packet) UnmarshalBinary(data []byte) error {
+	length := int(binary.BigEndian.Uint16(data[0:2]))
+
+	if len(data) < length {
+		return ErrInvalidPacket
+	}
+	p.Head = data[2 : length+2]
+
+	p.Body = data[length+2:]
+
+	return nil
+}

--- a/lob/coder_test.go
+++ b/lob/coder_test.go
@@ -1,0 +1,226 @@
+package lob
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func TestCreatePacket(t *testing.T) {
+	head := []byte{1, 2, 3}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{head, body}
+
+	if len(head) != len(p.Head) {
+		t.Errorf("Header lenght incorrect, %d != %d", len(head), len(p.Head))
+	}
+
+	if len(body) != len(p.Body) {
+		t.Errorf("Body lenght incorrect, %d != %d", len(body), len(p.Body))
+	}
+}
+
+func TestEncodeBinaryPacket(t *testing.T) {
+	head := []byte{1, 2, 3}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{head, body}
+
+	b, _ := p.MarshalBinary()
+
+	if len(b) != 2+len(head)+len(body) {
+		t.Errorf("Encoded lenght incorrect, %d != %d", len(b), 2+len(head)+len(body))
+	}
+
+	encLen := int(binary.BigEndian.Uint16(b[0:2]))
+	if encLen != len(head) {
+		t.Errorf("Header lenght incorrect, %d != %d", len(head), encLen)
+	}
+
+	encHead := b[2 : 2+encLen]
+	if !bytes.Equal(encHead, head) {
+		t.Error("Header encoding incorrect")
+	}
+
+	encBody := b[5:]
+	if !bytes.Equal(encBody, body) {
+		t.Error("Body encoding incorrect")
+	}
+}
+
+func TestDecodeBinaryPacket(t *testing.T) {
+	raw := []byte{0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	p := &Packet{}
+
+	_ = p.UnmarshalBinary(raw)
+
+	encLen := int(binary.BigEndian.Uint16(raw[0:2]))
+	if encLen != len(p.Head) {
+		t.Errorf("Header lenght incorrect, %d != %d", len(p.Head), encLen)
+	}
+
+	encHead := raw[2 : 2+encLen]
+	if !bytes.Equal(encHead, p.Head) {
+		t.Error("Header encoding incorrect")
+	}
+
+	encBody := raw[2+encLen:]
+	if !bytes.Equal(encBody, p.Body) {
+		t.Error("Body encoding incorrect")
+	}
+}
+
+func TestEncodeMaxLengthHeader(t *testing.T) {
+	head := [math.MaxUint16]byte{}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{head[:], body}
+
+	b, err := p.MarshalBinary()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	if len(b) != 2+len(head[:])+len(body) {
+		t.Errorf("Encoded lenght incorrect, %d != %d", len(b), 2+len(head)+len(body))
+	}
+
+	encLen := int(binary.BigEndian.Uint16(b[0:2]))
+	if encLen != len(head) {
+		t.Errorf("Header lenght incorrect, %d != %d", len(head), encLen)
+	}
+
+	encHead := b[2 : 2+encLen]
+	if !bytes.Equal(encHead, head[:]) {
+		t.Error("Header encoding incorrect")
+	}
+
+	encBody := b[2+encLen:]
+	if !bytes.Equal(encBody, body) {
+		t.Errorf("Body encoding incorrect, %v != %v", encBody, body)
+	}
+}
+
+func TestEncodeTooLongHeader(t *testing.T) {
+	head := [math.MaxUint16 + 1]byte{}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{head[:], body}
+
+	_, err := p.MarshalBinary()
+	if err != ErrHeaderTooLong {
+		t.Errorf("Encoded header that is longer than %v bytes, %v", math.MaxUint16, err)
+	}
+}
+
+func TestEncodeDecodeEmptyHeader(t *testing.T) {
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{}
+	p.Body = body
+	b, _ := p.MarshalBinary()
+
+	p2 := &Packet{}
+	_ = p2.UnmarshalBinary(b)
+
+	if !bytes.Equal(p.Head, p2.Head) {
+		t.Errorf("Re decoded header not equal, %v != %v", p.Head, p2.Head)
+	}
+
+	if len(p.Head) != 0 {
+		t.Errorf("Original Header not emtpy, len=%v", len(p.Head))
+	}
+
+	if len(p2.Head) != 0 {
+		t.Errorf("Decoded Header not emtpy, len=%v", len(p2.Head))
+	}
+
+	if !bytes.Equal(p.Body, p2.Body) {
+		t.Errorf("Re decoded body not equal, %v != %v", p.Body, p2.Body)
+	}
+}
+
+func TestEncodeDecodeBinaryHeader(t *testing.T) {
+	head := []byte{1, 2, 3}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{head, body}
+	b, _ := p.MarshalBinary()
+
+	p2 := &Packet{}
+	_ = p2.UnmarshalBinary(b)
+
+	if !bytes.Equal(p.Head, p2.Head) {
+		t.Errorf("Re decoded header not equal, %v != %v", p.Head, p2.Head)
+	}
+
+	if !bytes.Equal(p.Body, p2.Body) {
+		t.Errorf("Re decoded body not equal, %v != %v", p.Body, p2.Body)
+	}
+}
+
+func TestEncodeDecodeJSONHeader(t *testing.T) {
+	type testHead struct {
+		FirstField  int
+		SecondField string
+	}
+	head := testHead{1, "my field"}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{}
+	p.Body = body
+	p.Head.EncodeJSON(head)
+	b, _ := p.MarshalBinary()
+
+	p2 := &Packet{}
+	_ = p2.UnmarshalBinary(b)
+
+	var head2 testHead
+	p2.Head.DecodeJSON(&head2)
+
+	if head != head2 {
+		t.Errorf("Re decoded JSON header not equal, %v != %v", head, head2)
+	}
+
+	if !bytes.Equal(p.Head, p2.Head) {
+		t.Errorf("Re decoded header not equal, %v != %v", p.Head, p2.Head)
+	}
+
+	if !bytes.Equal(p.Body, p2.Body) {
+		t.Errorf("Re decoded body not equal, %v != %v", p.Body, p2.Body)
+	}
+
+}
+
+func TestEncodeDecodeBinaryHeaderAsJSON(t *testing.T) {
+	type testHead struct {
+		FirstField  int
+		SecondField string
+	}
+
+	head := []byte{1, 2, 3}
+	body := []byte{4, 5, 6, 7, 8, 9}
+
+	p := &Packet{head, body}
+	b, _ := p.MarshalBinary()
+
+	p2 := &Packet{}
+	_ = p2.UnmarshalBinary(b)
+
+	var head2 testHead
+	err := p2.Head.DecodeJSON(&head2)
+	if err != ErrNonJSONHeader {
+		t.Errorf("Non JSON header was decoded as JSON, %v", err)
+	}
+
+	if !bytes.Equal(p.Head, p2.Head) {
+		t.Errorf("Re decoded header not equal, %v != %v", p.Head, p2.Head)
+	}
+
+	if !bytes.Equal(p.Body, p2.Body) {
+		t.Errorf("Re decoded body not equal, %v != %v", p.Body, p2.Body)
+	}
+}


### PR DESCRIPTION
IMPORTANT: This pull request is not meant to be merged, it is for review and discussion.

I would like to use LOB encoding for additionally data than what is specified in Telehash.
So I rewrote the LOB encoder allow encode and decode of arbitrary structs as JSON headers. It is similar in spirit to the encoding packages in go.

@fd I would appreciate your feedback on it. 
I din't implement all the optimizations you have with the pools, but I don't feel the need for it at the moment.
